### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#Touch Color
+# Touch Color
 
 1.0版本已于AppStore上架  [AppStore 链接](https://itunes.apple.com/cn/app/touchcolor/id859727780?mt=8)
 
 一个优雅简洁，功能完善的取色器。照片取色，照相取色，实时取色三大功能为你带来移动平台最优秀的取色体验。
 
-###1.0版本主要功能
+### 1.0版本主要功能
 1. 主要功能
    - 照片取色功能  
    - 实时取色功能
@@ -14,7 +14,7 @@
    - 利用GPUImage实时解析颜色
    - 利用CGBitmapContext提取点颜色
 
-###2.0版本进行中
+### 2.0版本进行中
 1. 优化特点   
    - 全面适配iPhone6，iPhone6 Plus
    - 添加图片色调提取功能


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
